### PR TITLE
Changes based on Ben's advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ Included this module in Account and Transaction classes.
 - Inputs sanitised to pence with `to_pence`.
 - Return strings etc format from pence to pounds with 2 decimals with `as_pounds`.
 
+Refactored `as_pounds` to use the `format` method instead of `sprintf` as per Rubocop suggestion.
 
 <!-- Links -->
 

--- a/README.md
+++ b/README.md
@@ -443,6 +443,11 @@ Wrote test for the print method, passing an array prints each element on a new l
 
 - Added an if else statement to check if the item passed is a string, if so puts it, else it is an array to join with new lines and puts that
 
+Refactored to use a ternary operator.
+
+- Injected the new Printer class into the Account class with keyword argument to `initialize`.
+- `@printer` is assigned with a new instance of the injected printer.
+- Reworked `statement` to print using `@printer.print`
 
 <!-- Links -->
 

--- a/README.md
+++ b/README.md
@@ -439,6 +439,9 @@ Wrote test for the print method, passing "Hi There" prints "Hi There" to stdout 
 
 Green.
 
+Wrote test for the print method, passing an array prints each element on a new line. Red.
+
+- Added an if else statement to check if the item passed is a string, if so puts it, else it is an array to join with new lines and puts that
 
 
 <!-- Links -->

--- a/README.md
+++ b/README.md
@@ -460,7 +460,8 @@ In `lib/conversion.rb`:
 - Created a new method, `to_pence`, taking an amount, multiplying by 100 then converting to integer.
 - Created a new method, `as_pounds`, calling the `sprintf` method with two decimal places, and the passed amount (as pence) divided by 100.
 
-- Included this module in Account and Transaction classes.
+Included this module in Account and Transaction classes.
+
 - Inputs sanitised to pence with `to_pence`.
 - Return strings etc format from pence to pounds with 2 decimals with `as_pounds`.
 

--- a/README.md
+++ b/README.md
@@ -454,6 +454,15 @@ Wrote test that `statement` uses printer class.
 
 ### Refactoring To Use Pence
 
+In `lib/conversion.rb`:
+
+- Created a new module, Conversion.
+- Created a new method, `to_pence`, taking an amount, multiplying by 100 then converting to integer.
+- Created a new method, `as_pounds`, calling the `sprintf` method with two decimal places, and the passed amount (as pence) divided by 100.
+
+- Included this module in Account and Transaction classes.
+- Inputs sanitised to pence with `to_pence`.
+- Return strings etc format from pence to pounds with 2 decimals with `as_pounds`.
 
 
 <!-- Links -->

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- omit in toc -->
+
 # Bank
 
 This is a small project to practice maintaining code quality and process. [Source]
@@ -22,7 +24,7 @@ It allows you to create an account, deposit funds into it, withdraw funds from i
     - [Statement](#statement)
     - [Transactions](#transactions)
     - [Back to Account Statement](#back-to-account-statement)
-    - [Clean Up](#clean-up)
+    - [Simplecov and Rubocop](#simplecov-and-rubocop)
     - [Pretty Deposit & Withdraw Returns](#pretty-deposit--withdraw-returns)
     - [Pretty Print Statement](#pretty-print-statement)
     - [Extracting a Printer Class](#extracting-a-printer-class)
@@ -39,10 +41,10 @@ It allows you to create an account, deposit funds into it, withdraw funds from i
 
 ### Acceptance criteria
 
-**Given** a client makes a deposit of 1000 on 10-01-2012
-**And** a deposit of 2000 on 13-01-2012
-**And** a withdrawal of 500 on 14-01-2012
-**When** she prints her bank statement
+**Given** a client makes a deposit of 1000 on 10-01-2012  
+**And** a deposit of 2000 on 13-01-2012  
+**And** a withdrawal of 500 on 14-01-2012  
+**When** she prints her bank statement  
 **Then** she would see:
 
 ```irb
@@ -82,11 +84,11 @@ date || credit || debit || balance
 
 5. Use your account with the following methods
 
-| Method                   | Description                                             |
-| ------------------------ | ------------------------------------------------------- |
-| account.deposit(number)  | deposit however much you want into your account where  |
-| account.withdraw(number) | withdraw however much you want from your account where |
-| p account.statement      | prints a statement of all transactions so far           |
+| Method                     | Description                                      |
+| -------------------------- | ------------------------------------------------ |
+| `account.deposit(number)`  | deposit however much you want into your account  |
+| `account.withdraw(number)` | withdraw however much you want from your account |
+| `account.statement`        | prints a statement of all transactions so far    |
 
 You should see something similar to the below in your terminal:
 
@@ -263,6 +265,8 @@ Green.
 
 Refactored to guard clause from if block.
 
+_Later refactored to simply return a string 'Insufficient funds', rather than raising a runtime error._
+
 ### Statement
 
 - [x] 4
@@ -389,7 +393,7 @@ Refactors:
 - Extracted constant `STATEMENT_HEADER` from the `statement` method.
 - Used `&:display` in the statement map to proc the display method on the element rather than using a full map block.
 
-### Clean Up
+### Simplecov and Rubocop
 
 Added simplecov and simplecov console gems and configured them in `spec_helper.rb` to check code coverage (better late than never). Also added `coverage` to `.gitignore`.
 
@@ -399,6 +403,9 @@ Based on Rubocop suggestions:
 
 - Renamed several variable and method names to snake_case convention (been doing too much JavaSript it seems).
 - Excluded spec files in `.rubocop.yml` as these tend to have large blocks and long lines (e.g. the result of the feature tests.)
+
+Also:
+
 - Account `initialise` method sets `@balance` with new constant `STARTING_BALANCE` as 0.
 
 ### Pretty Deposit & Withdraw Returns

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This is a small project to practice maintaining code quality and process. [Source]
 
-It allows you to create an account, deposit funds into it, withdraw funds from it, and get statements.
+It allows you to create an account, deposit funds into it, withdraw funds from it, and print statements.
 
 - [Spec](#spec)
   - [Requirements](#requirements)

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ date || credit || debit || balance
 
 | Method                     | Description                                      |
 | -------------------------- | ------------------------------------------------ |
-| `account.deposit(number)`  | deposit however much you want into your account  |
-| `account.withdraw(number)` | withdraw however much you want from your account |
+| `account.deposit(number)`  | deposit however much you want into your account, this figure is in pounds with pence as decimals.  |
+| `account.withdraw(number)` | withdraw however much you want from your account, this figure is in pounds with pence as decimals. |
 | `account.statement`        | prints a statement of all transactions so far    |
 
 You should see something similar to the below in your terminal:

--- a/README.md
+++ b/README.md
@@ -435,6 +435,11 @@ Green.
 
 Wrote test for the print method, passing "Hi There" prints "Hi There" to stdout with a newline. Red.
 
+- `print` puts what you pass in as argument.
+
+Green.
+
+
 
 <!-- Links -->
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It allows you to create an account, deposit funds into it, withdraw funds from i
     - [Clean Up](#clean-up)
     - [Pretty Deposit & Withdraw Returns](#pretty-deposit--withdraw-returns)
     - [Pretty Print Statement](#pretty-print-statement)
+    - [Extracting a Printer Class](#extracting-a-printer-class)
 
 ## Spec
 
@@ -417,6 +418,23 @@ Adjusted the feature tests to check for output to standard out rather than just 
 Added a puts to the `statement` so the result is printed out properly, rather than returning a poorly formatted string.
 
 Green.
+
+### Extracting a Printer Class
+
+It was pointed out to me that there could be a printer class.
+
+In `spec/printer_spec.rb`:
+
+Wrote test for a print method, passing "Hello World" prints "Hello World" to stdout with a newline. Red.
+
+In `lib/printer.rb`:
+
+- Added a Printer class with method `print` that puts "Hello World"
+
+Green.
+
+Wrote test for the print method, passing "Hi There" prints "Hi There" to stdout with a newline. Red.
+
 
 <!-- Links -->
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ date || credit || debit || balance
 
 5. Use your account with the following methods
 
-| Method              | Description                                        |
-| ------------------- | -------------------------------------------------- |
-| account.deposit(n)  | deposit n into your account where x is an integer  |
-| account.withdraw(n) | withdraw n from your account where x is an integer |
-| p account.statement | prints a statement of all transactions so far      |
+| Method                   | Description                                             |
+| ------------------------ | ------------------------------------------------------- |
+| account.deposit(number)  | deposit however much you want into your account where  |
+| account.withdraw(number) | withdraw however much you want from your account where |
+| p account.statement      | prints a statement of all transactions so far           |
 
 You should see something similar to the below in your terminal:
 

--- a/README.md
+++ b/README.md
@@ -1,34 +1,32 @@
 <!-- omit in toc -->
-
 # Bank
 
 This is a small project to practice maintaining code quality and process. [Source]
 
 It allows you to create an account, deposit funds into it, withdraw funds from it, and get statements.
 
-- [Bank](#bank)
-  - [Spec](#spec)
-    - [Requirements](#requirements)
-    - [Acceptance criteria](#acceptance-criteria)
-  - [Quick Start](#quick-start)
-  - [Screen Preview](#screen-preview)
-  - [Gems](#gems)
-    - [Rubocop Configuration](#rubocop-configuration)
-  - [Development Journal](#development-journal)
-    - [Domain Modelling](#domain-modelling)
-    - [User Stories](#user-stories)
-    - [Set up](#set-up)
-    - [Accounts](#accounts)
-    - [Deposits](#deposits)
-    - [Withdrawals](#withdrawals)
-    - [Statement](#statement)
-    - [Transactions](#transactions)
-    - [Back to Account Statement](#back-to-account-statement)
-    - [Simplecov and Rubocop](#simplecov-and-rubocop)
-    - [Pretty Deposit & Withdraw Returns](#pretty-deposit--withdraw-returns)
-    - [Pretty Print Statement](#pretty-print-statement)
-    - [Extracting a Printer Class](#extracting-a-printer-class)
-    - [Refactoring To Use Pence](#refactoring-to-use-pence)
+- [Spec](#spec)
+  - [Requirements](#requirements)
+  - [Acceptance criteria](#acceptance-criteria)
+- [Quick Start](#quick-start)
+- [Screen Preview](#screen-preview)
+- [Gems](#gems)
+  - [Rubocop Configuration](#rubocop-configuration)
+- [Development Journal](#development-journal)
+  - [Domain Modelling](#domain-modelling)
+  - [User Stories](#user-stories)
+  - [Set up](#set-up)
+  - [Accounts](#accounts)
+  - [Deposits](#deposits)
+  - [Withdrawals](#withdrawals)
+  - [Statement](#statement)
+  - [Transactions](#transactions)
+  - [Back to Account Statement](#back-to-account-statement)
+  - [Simplecov and Rubocop](#simplecov-and-rubocop)
+  - [Pretty Deposit & Withdraw Returns](#pretty-deposit--withdraw-returns)
+  - [Pretty Print Statement](#pretty-print-statement)
+  - [Extracting a Printer Class](#extracting-a-printer-class)
+  - [Refactoring To Use Pence](#refactoring-to-use-pence)
 
 ## Spec
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ It allows you to create an account, deposit funds into it, withdraw funds from i
     - [Pretty Deposit & Withdraw Returns](#pretty-deposit--withdraw-returns)
     - [Pretty Print Statement](#pretty-print-statement)
     - [Extracting a Printer Class](#extracting-a-printer-class)
+    - [Refactoring To Use Pence](#refactoring-to-use-pence)
 
 ## Spec
 
@@ -445,9 +446,15 @@ Wrote test for the print method, passing an array prints each element on a new l
 
 Refactored to use a ternary operator.
 
+Wrote test that `statement` uses printer class.
+
 - Injected the new Printer class into the Account class with keyword argument to `initialize`.
 - `@printer` is assigned with a new instance of the injected printer.
-- Reworked `statement` to print using `@printer.print`
+- Reworked `statement` to print using `@printer.print`.
+
+### Refactoring To Use Pence
+
+
 
 <!-- Links -->
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,54 @@
 
 This is a small project to practice maintaining code quality and process. [Source]
 
+It allows you to create an account, deposit funds into it, withdraw funds from it, and get statements.
+
+- [Bank](#bank)
+  - [Spec](#spec)
+    - [Requirements](#requirements)
+    - [Acceptance criteria](#acceptance-criteria)
+  - [Quick Start](#quick-start)
+  - [Screen Preview](#screen-preview)
+  - [Gems](#gems)
+    - [Rubocop Configuration](#rubocop-configuration)
+  - [Development Journal](#development-journal)
+    - [Domain Modelling](#domain-modelling)
+    - [User Stories](#user-stories)
+    - [Set up](#set-up)
+    - [Accounts](#accounts)
+    - [Deposits](#deposits)
+    - [Withdrawals](#withdrawals)
+    - [Statement](#statement)
+    - [Transactions](#transactions)
+    - [Back to Account Statement](#back-to-account-statement)
+    - [Clean Up](#clean-up)
+    - [Pretty Deposit & Withdraw Returns](#pretty-deposit--withdraw-returns)
+    - [Pretty Print Statement](#pretty-print-statement)
+
+## Spec
+
+### Requirements
+
+- You should be able to interact with your code via a REPL like IRB or the JavaScript console. (You don't need to implement a command line interface that takes input from STDIN.)
+- Deposits, withdrawal.
+- Account statement (date, amount, balance) printing.
+- Data can be kept in memory (it doesn't need to be stored to a database or anything).
+
+### Acceptance criteria
+
+**Given** a client makes a deposit of 1000 on 10-01-2012
+**And** a deposit of 2000 on 13-01-2012
+**And** a withdrawal of 500 on 14-01-2012
+**When** she prints her bank statement
+**Then** she would see:
+
+```irb
+date || credit || debit || balance
+14/01/2012 || || 500.00 || 2500.00
+13/01/2012 || 2000.00 || || 3000.00
+10/01/2012 || 1000.00 || || 1000.00
+```
+
 ## Quick Start
 
 1. Clone this repo.
@@ -38,7 +86,9 @@ This is a small project to practice maintaining code quality and process. [Sourc
 | account.withdraw(n) | withdraw n from your account where x is an integer |
 | p account.statement | prints a statement of all transactions so far      |
 
-You should see somthing similar to the below in your terminal:
+You should see something similar to the below in your terminal:
+
+## Screen Preview
 
 ![Screen preview](images/bank-screen-preview.png)
 
@@ -55,29 +105,13 @@ Testing and Development gems are:
 | simplecov         | Measures test coverage                            |
 | simplecov-console | Displays measured test coverage when rspec is run |
 
-## Spec
+### Rubocop Configuration
 
-### Requirements
+Rubocop config is specified in `.rubocop.yml`.
 
-- You should be able to interact with your code via a REPL like IRB or the JavaScript console. (You don't need to implement a command line interface that takes input from STDIN.)
-- Deposits, withdrawal.
-- Account statement (date, amount, balance) printing.
-- Data can be kept in memory (it doesn't need to be stored to a database or anything).
+Configured to ignore any file in the `spec` directory, and the `Gemfile`.
 
-### Acceptance criteria
-
-**Given** a client makes a deposit of 1000 on 10-01-2012
-**And** a deposit of 2000 on 13-01-2012
-**And** a withdrawal of 500 on 14-01-2012
-**When** she prints her bank statement
-**Then** she would see:
-
-```irb
-date || credit || debit || balance
-14/01/2012 || || 500.00 || 2500.00
-13/01/2012 || 2000.00 || || 3000.00
-10/01/2012 || 1000.00 || || 1000.00
-```
+I have also disabled to documentation ruleset, to prevent it applying the `Missing top-level class documentation comment` rule (which for this small project is a bit overkill).
 
 ## Development Journal
 

--- a/lib/account.rb
+++ b/lib/account.rb
@@ -2,8 +2,11 @@
 
 require_relative './transaction.rb'
 require_relative './printer.rb'
+require_relative './conversion.rb'
 
 class Account
+  include Conversion
+
   STATEMENT_HEADER = "date || credit || debit || balance\n"
   STARTING_BALANCE = 0
 
@@ -15,17 +18,19 @@ class Account
   end
 
   def deposit(amount)
-    @balance += amount
-    add_deposit(credit: amount, balance: @balance)
-    "#{amount}.00 deposited. Current balance: #{@balance}.00"
+    pence = to_pence(amount)
+    @balance += pence
+    add_deposit(credit: pence, balance: @balance)
+    "#{as_pounds(pence)} deposited. Current balance: #{as_pounds(@balance)}"
   end
 
   def withdraw(amount)
-    return 'Insufficient funds' if @balance < amount
+    pence = to_pence(amount)
+    return 'Insufficient funds' if @balance < pence
 
-    @balance -= amount
-    add_withrawal(debit: amount, balance: @balance)
-    "#{amount}.00 withdrawn. Current balance: #{@balance}.00"
+    @balance -= pence
+    add_withrawal(debit: pence, balance: @balance)
+    "#{as_pounds(pence)} withdrawn. Current balance: #{as_pounds(@balance)}"
   end
 
   def statement

--- a/lib/account.rb
+++ b/lib/account.rb
@@ -6,7 +6,7 @@ class Account
   STATEMENT_HEADER = "date || credit || debit || balance\n"
   STARTING_BALANCE = 0
 
-  def initialize(transaction_class = Transaction)
+  def initialize(transaction_class: Transaction)
     @balance = STARTING_BALANCE
     @transaction_class = transaction_class
     @transaction_history = []

--- a/lib/account.rb
+++ b/lib/account.rb
@@ -19,7 +19,7 @@ class Account
   end
 
   def withdraw(amount)
-    raise 'Insufficient funds' if @balance < amount
+    return 'Insufficient funds' if @balance < amount
 
     @balance -= amount
     add_withrawal(debit: amount, balance: @balance)

--- a/lib/account.rb
+++ b/lib/account.rb
@@ -9,7 +9,7 @@ class Account
   def initialize(transaction_class = Transaction)
     @balance = STARTING_BALANCE
     @transaction_class = transaction_class
-    @history = []
+    @transaction_history = []
   end
 
   def deposit(amount)
@@ -27,17 +27,17 @@ class Account
   end
 
   def statement
-    statement_rows = @history.map(&:display)
+    statement_rows = @transaction_history.map(&:display)
     puts STATEMENT_HEADER + statement_rows.join("\n")
   end
 
   private
 
   def add_deposit(credit: nil, balance: nil)
-    @history.unshift @transaction_class.new(credit: credit, balance: balance)
+    @transaction_history.unshift @transaction_class.new(credit: credit, balance: balance)
   end
 
   def add_withrawal(debit: nil, balance: nil)
-    @history.unshift @transaction_class.new(debit: debit, balance: balance)
+    @transaction_history.unshift @transaction_class.new(debit: debit, balance: balance)
   end
 end

--- a/lib/account.rb
+++ b/lib/account.rb
@@ -30,17 +30,19 @@ class Account
 
   def statement
     statement_rows = @transaction_history.map(&:display)
-    @printer.print STATEMENT_HEADER 
+    @printer.print STATEMENT_HEADER
     @printer.print statement_rows
   end
 
   private
 
   def add_deposit(credit: nil, balance: nil)
-    @transaction_history.unshift @transaction_class.new(credit: credit, balance: balance)
+    deposit = @transaction_class.new(credit: credit, balance: balance)
+    @transaction_history.unshift deposit
   end
 
   def add_withrawal(debit: nil, balance: nil)
-    @transaction_history.unshift @transaction_class.new(debit: debit, balance: balance)
+    withdrawal = @transaction_class.new(debit: debit, balance: balance)
+    @transaction_history.unshift withdrawal
   end
 end

--- a/lib/account.rb
+++ b/lib/account.rb
@@ -18,19 +18,19 @@ class Account
   end
 
   def deposit(amount)
-    pence = to_pence(amount)
-    @balance += pence
-    add_deposit(credit: pence, balance: @balance)
-    "#{as_pounds(pence)} deposited. Current balance: #{as_pounds(@balance)}"
+    credit = to_pence(amount)
+    @balance += credit
+    add_deposit(credit: credit, balance: @balance)
+    "#{as_pounds(credit)} deposited. Current balance: #{as_pounds(@balance)}"
   end
 
   def withdraw(amount)
-    pence = to_pence(amount)
+    debit = to_pence(amount)
     return 'Insufficient funds' if @balance < pence
 
-    @balance -= pence
-    add_withrawal(debit: pence, balance: @balance)
-    "#{as_pounds(pence)} withdrawn. Current balance: #{as_pounds(@balance)}"
+    @balance -= debit
+    add_withrawal(debit: debit, balance: @balance)
+    "#{as_pounds(debit)} withdrawn. Current balance: #{as_pounds(@balance)}"
   end
 
   def statement

--- a/lib/account.rb
+++ b/lib/account.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 require_relative './transaction.rb'
+require_relative './printer.rb'
 
 class Account
   STATEMENT_HEADER = "date || credit || debit || balance\n"
   STARTING_BALANCE = 0
 
-  def initialize(transaction_class: Transaction)
+  def initialize(transaction_class: Transaction, printer_class: Printer)
     @balance = STARTING_BALANCE
     @transaction_class = transaction_class
+    @printer = printer_class.new
     @transaction_history = []
   end
 
@@ -28,7 +30,8 @@ class Account
 
   def statement
     statement_rows = @transaction_history.map(&:display)
-    puts STATEMENT_HEADER + statement_rows.join("\n")
+    @printer.print STATEMENT_HEADER 
+    @printer.print statement_rows
   end
 
   private

--- a/lib/conversion.rb
+++ b/lib/conversion.rb
@@ -2,4 +2,8 @@ module Conversion
   def to_pence(amount)
     (amount * 100).to_i
   end
+
+  def as_pounds(amount)
+    sprintf "%.2f", amount / 100
+  end
 end

--- a/lib/conversion.rb
+++ b/lib/conversion.rb
@@ -1,0 +1,5 @@
+module Conversion
+  def to_pence(amount)
+    (amount * 100).to_i
+  end
+end

--- a/lib/conversion.rb
+++ b/lib/conversion.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module Conversion
   def to_pence(amount)
     (amount * 100).to_i
   end
 
   def as_pounds(amount)
-    sprintf "%.2f", amount / 100
+    format('%<amount>.2f', amount: amount / 100)
   end
 end

--- a/lib/printer.rb
+++ b/lib/printer.rb
@@ -1,9 +1,5 @@
 class Printer
   def print(item)
-    if item.kind_of?(String)
-      puts item
-    else
-      puts item.join("\n")
-    end
+    puts item.kind_of?(String) ? item : item.join("\n")
   end
 end

--- a/lib/printer.rb
+++ b/lib/printer.rb
@@ -1,5 +1,9 @@
 class Printer
   def print(item)
-    puts item
+    if item.kind_of?(String)
+      puts item
+    else
+      puts item.join("\n")
+    end
   end
 end

--- a/lib/printer.rb
+++ b/lib/printer.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class Printer
   def print(item)
-    puts item.kind_of?(String) ? item : item.join("\n")
+    puts item.is_a?(String) ? item : item.join("\n")
   end
 end

--- a/lib/printer.rb
+++ b/lib/printer.rb
@@ -1,0 +1,5 @@
+class Printer
+  def print(item)
+    puts 'Hello World'
+  end
+end

--- a/lib/printer.rb
+++ b/lib/printer.rb
@@ -1,5 +1,5 @@
 class Printer
   def print(item)
-    puts 'Hello World'
+    puts item
   end
 end

--- a/lib/transaction.rb
+++ b/lib/transaction.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require_relative './conversion.rb'
+
 class Transaction
+  include Conversion
+
   def initialize(credit: nil, debit: nil, balance: nil)
     @time = Time.now
     @credit = credit
@@ -15,7 +19,7 @@ class Transaction
   private
 
   def format(item)
-    "#{item}.00 " if item
+    "#{as_pounds(item)} " if item
   end
 
   def time

--- a/spec/account_feature_spec.rb
+++ b/spec/account_feature_spec.rb
@@ -19,9 +19,15 @@ describe 'Account Feature Test' do
     allow(Time).to receive(:now).and_return(time_three)
     subject.withdraw(500)
 
-    statement = "date || credit || debit || balance\n14/01/2012 || || 500.00 || 2500.00 \n13/01/2012 || 2000.00 || || 3000.00 \n10/01/2012 || 1000.00 || || 1000.00 "
+    statement_header  = "date || credit || debit || balance "
+    transaction_one   = /14\/01\/2012 \|\| \|\| 500.00 \|\| 2500.00 /
+    transaction_two   = /13\/01\/2012 \|\| 2000.00 \|\| \|\| 3000.00 /
+    transaction_three = /10\/01\/2012 \|\| 1000.00 \|\| \|\| 1000.00 /
 
-    expect{ subject.statement }.to output(/#{statement}/m).to_stdout
+    expect{ subject.statement }.to output(/#{statement_header}/m).to_stdout
+    expect{ subject.statement }.to output(transaction_one).to_stdout
+    expect{ subject.statement }.to output(transaction_two).to_stdout
+    expect{ subject.statement }.to output(transaction_three).to_stdout
   end
 
   it 'deposit 2000, 3000 then withdraw 1500' do
@@ -40,8 +46,14 @@ describe 'Account Feature Test' do
     allow(Time).to receive(:now).and_return(time_three)
     subject.withdraw(1500)
 
-    statement = "date || credit || debit || balance\n14/01/2012 || || 1500.00 || 3500.00 \n13/01/2012 || 3000.00 || || 5000.00 \n10/01/2012 || 2000.00 || || 2000.00 "
+    statement_header  = "date || credit || debit || balance "
+    transaction_one   = /14\/01\/2012 \|\| \|\| 1500.00 \|\| 3500.00 /
+    transaction_two   = /13\/01\/2012 \|\| 3000.00 \|\| \|\| 5000.00 /
+    transaction_three = /10\/01\/2012 \|\| 2000.00 \|\| \|\| 2000.00 /
 
-    expect{ subject.statement }.to output(/#{statement}/m).to_stdout
+    expect{ subject.statement }.to output(/#{statement_header}/m).to_stdout
+    expect{ subject.statement }.to output(transaction_one).to_stdout
+    expect{ subject.statement }.to output(transaction_two).to_stdout
+    expect{ subject.statement }.to output(transaction_three).to_stdout
   end
 end

--- a/spec/account_feature_spec.rb
+++ b/spec/account_feature_spec.rb
@@ -4,19 +4,19 @@ require 'account'
 
 describe 'Account Feature Test' do
   it 'deposit 1000, 2000 then withdraw 500' do
-    time1 = Time.new(2012, 1, 10, 12)
-    time2 = Time.new(2012, 1, 13, 12)
-    time3 = Time.new(2012, 1, 14, 12)
+    time_one = Time.new(2012, 1, 10, 12)
+    time_two = Time.new(2012, 1, 13, 12)
+    time_three = Time.new(2012, 1, 14, 12)
 
     subject = Account.new
 
-    allow(Time).to receive(:now).and_return(time1)
+    allow(Time).to receive(:now).and_return(time_one)
     subject.deposit(1000)
 
-    allow(Time).to receive(:now).and_return(time2)
+    allow(Time).to receive(:now).and_return(time_two)
     subject.deposit(2000)
 
-    allow(Time).to receive(:now).and_return(time3)
+    allow(Time).to receive(:now).and_return(time_three)
     subject.withdraw(500)
 
     statement = "date || credit || debit || balance\n14/01/2012 || || 500.00 || 2500.00 \n13/01/2012 || 2000.00 || || 3000.00 \n10/01/2012 || 1000.00 || || 1000.00 "
@@ -25,19 +25,19 @@ describe 'Account Feature Test' do
   end
 
   it 'deposit 2000, 3000 then withdraw 1500' do
-    time1 = Time.new(2012, 1, 10, 12)
-    time2 = Time.new(2012, 1, 13, 12)
-    time3 = Time.new(2012, 1, 14, 12)
+    time_one = Time.new(2012, 1, 10, 12)
+    time_two = Time.new(2012, 1, 13, 12)
+    time_three = Time.new(2012, 1, 14, 12)
 
     subject = Account.new
 
-    allow(Time).to receive(:now).and_return(time1)
+    allow(Time).to receive(:now).and_return(time_one)
     subject.deposit(2000)
 
-    allow(Time).to receive(:now).and_return(time2)
+    allow(Time).to receive(:now).and_return(time_two)
     subject.deposit(3000)
 
-    allow(Time).to receive(:now).and_return(time3)
+    allow(Time).to receive(:now).and_return(time_three)
     subject.withdraw(1500)
 
     statement = "date || credit || debit || balance\n14/01/2012 || || 1500.00 || 3500.00 \n13/01/2012 || 3000.00 || || 5000.00 \n10/01/2012 || 2000.00 || || 2000.00 "

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -39,11 +39,11 @@ describe Account do
     it 'deposit calls for a new transaction with the credit amount and balance' do
       transaction_class = double(:transaction_class, new: "got new")
       subject = described_class.new(transaction_class: transaction_class)
-      
+
       expect(transaction_class).to receive(:new).with(credit: 10000, balance: 10000)
       subject.deposit(100)
     end
-    
+
     it 'withdraw calls for a new transaction with the debit amount and balance' do
       transaction_class = double(:transaction_class, new: "got new")
       subject = described_class.new(transaction_class: transaction_class)

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -38,7 +38,7 @@ describe Account do
   describe 'uses Transaction class' do
     it 'deposit calls for a new transaction with the credit amount and balance' do
       transaction_class = double(:transaction_class, new: "got new")
-      subject = Account.new(transaction_class: transaction_class)
+      subject = described_class.new(transaction_class: transaction_class)
       
       expect(transaction_class).to receive(:new).with(credit: 100, balance: 100)
       subject.deposit(100)
@@ -46,7 +46,7 @@ describe Account do
     
     it 'withdraw calls for a new transaction with the debit amount and balance' do
       transaction_class = double(:transaction_class, new: "got new")
-      subject = Account.new(transaction_class: transaction_class)
+      subject = described_class.new(transaction_class: transaction_class)
 
       subject.deposit(1000)
       expect(transaction_class).to receive(:new).with(debit: 100, balance: 900)

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -53,4 +53,13 @@ describe Account do
       subject.withdraw(100)
     end
   end
+
+  it '.statement uses printer class' do
+    printer = double(:printer)
+    printer_class = double(:printer_class, new: printer)
+    subject = described_class.new(printer_class: printer_class)
+
+    expect(printer).to receive(:print).twice
+    subject.statement
+  end
 end

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -38,7 +38,7 @@ describe Account do
   describe 'uses Transaction class' do
     it 'deposit calls for a new transaction with the credit amount and balance' do
       transaction_class = double(:transaction_class, new: "got new")
-      subject = Account.new(transaction_class)
+      subject = Account.new(transaction_class: transaction_class)
       
       expect(transaction_class).to receive(:new).with(credit: 100, balance: 100)
       subject.deposit(100)
@@ -46,8 +46,8 @@ describe Account do
     
     it 'withdraw calls for a new transaction with the debit amount and balance' do
       transaction_class = double(:transaction_class, new: "got new")
-      subject = Account.new(transaction_class)
-      
+      subject = Account.new(transaction_class: transaction_class)
+
       subject.deposit(1000)
       expect(transaction_class).to receive(:new).with(debit: 100, balance: 900)
       subject.withdraw(100)

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -30,9 +30,9 @@ describe Account do
     it 'withdrawing 200 results in a balance of 800' do
       expect(subject.withdraw(200)).to eq '200.00 withdrawn. Current balance: 800.00'
     end
-
+    
     it 'withdrawing 1500 throws Insuficcient funds' do
-      expect { subject.withdraw(1500) }.to raise_error('Insufficient funds')
+      expect(subject.withdraw(1500)).to eq 'Insufficient funds'
     end
   end
 

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -40,7 +40,7 @@ describe Account do
       transaction_class = double(:transaction_class, new: "got new")
       subject = described_class.new(transaction_class: transaction_class)
       
-      expect(transaction_class).to receive(:new).with(credit: 100, balance: 100)
+      expect(transaction_class).to receive(:new).with(credit: 10000, balance: 10000)
       subject.deposit(100)
     end
     
@@ -49,7 +49,7 @@ describe Account do
       subject = described_class.new(transaction_class: transaction_class)
 
       subject.deposit(1000)
-      expect(transaction_class).to receive(:new).with(debit: 100, balance: 900)
+      expect(transaction_class).to receive(:new).with(debit: 10000, balance: 90000)
       subject.withdraw(100)
     end
   end

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -36,17 +36,18 @@ describe Account do
   end
 
   describe 'uses Transaction class' do
-    let(:transaction) { double(:transaction) }
-    let(:transaction_class) { double(:transaction_class, new: transaction) }
-
-    subject { Account.new(transaction_class) }
-
     it 'deposit calls for a new transaction with the credit amount and balance' do
+      transaction_class = double(:transaction_class, new: "got new")
+      subject = Account.new(transaction_class)
+      
       expect(transaction_class).to receive(:new).with(credit: 100, balance: 100)
       subject.deposit(100)
     end
-
+    
     it 'withdraw calls for a new transaction with the debit amount and balance' do
+      transaction_class = double(:transaction_class, new: "got new")
+      subject = Account.new(transaction_class)
+      
       subject.deposit(1000)
       expect(transaction_class).to receive(:new).with(debit: 100, balance: 900)
       subject.withdraw(100)

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -19,19 +19,18 @@ describe Account do
   end
   
   describe '.withdraw (with 1000 deposited first)' do
-    before(:each) do
-      subject.deposit(1000)
-    end
-    
     it 'withdrawing 100 results in a balance of 900' do
+      subject.deposit(1000)
       expect(subject.withdraw(100)).to eq '100.00 withdrawn. Current balance: 900.00'
     end
     
     it 'withdrawing 200 results in a balance of 800' do
+      subject.deposit(1000)
       expect(subject.withdraw(200)).to eq '200.00 withdrawn. Current balance: 800.00'
     end
     
     it 'withdrawing 1500 throws Insuficcient funds' do
+      subject.deposit(1000)
       expect(subject.withdraw(1500)).to eq 'Insufficient funds'
     end
   end

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -54,12 +54,14 @@ describe Account do
     end
   end
 
-  it '.statement uses printer class' do
-    printer = double(:printer)
-    printer_class = double(:printer_class, new: printer)
-    subject = described_class.new(printer_class: printer_class)
+  describe '.statement' do
+    it 'uses printer class' do
+      printer = double(:printer)
+      printer_class = double(:printer_class, new: printer)
+      subject = described_class.new(printer_class: printer_class)
 
-    expect(printer).to receive(:print).twice
-    subject.statement
+      expect(printer).to receive(:print).twice
+      subject.statement
+    end
   end
 end

--- a/spec/printer_spec.rb
+++ b/spec/printer_spec.rb
@@ -1,0 +1,10 @@
+require 'printer'
+
+describe Printer do
+  describe '.print' do
+    it '"Hello World" prints "Hello World" with newline' do
+      expect { subject.print('Hello World') }.to output("Hello World\n").to_stdout
+    end
+      
+  end
+end

--- a/spec/printer_spec.rb
+++ b/spec/printer_spec.rb
@@ -5,6 +5,8 @@ describe Printer do
     it '"Hello World" prints "Hello World" with newline' do
       expect { subject.print('Hello World') }.to output("Hello World\n").to_stdout
     end
-      
+    it '"Hi There" prints "Hi There" with newline' do
+      expect { subject.print('Hi There') }.to output("Hi There\n").to_stdout
+    end
   end
 end

--- a/spec/printer_spec.rb
+++ b/spec/printer_spec.rb
@@ -5,8 +5,15 @@ describe Printer do
     it '"Hello World" prints "Hello World" with newline' do
       expect { subject.print('Hello World') }.to output("Hello World\n").to_stdout
     end
+
     it '"Hi There" prints "Hi There" with newline' do
       expect { subject.print('Hi There') }.to output("Hi There\n").to_stdout
+    end
+
+    it 'passing an array prints each element on a new line' do
+      array = ['Hello', 'World']
+      result = "Hello\nWorld\n"
+      expect { subject.print(array) }.to output(result).to_stdout
     end
   end
 end

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -7,7 +7,7 @@ describe Transaction do
     it 'has the time in the first column' do
       expect(subject.display).to eq "#{test_time_format} || || || "
     end
-    
+
     it 'has the credit it is initialised with in the second column' do
       subject = described_class.new(credit: 50000)
       expect(subject.display).to eq "#{test_time_format} || 500.00 || || "
@@ -22,7 +22,7 @@ describe Transaction do
       subject = described_class.new(balance: 200000)
       expect(subject.display).to eq "#{test_time_format} || || || 2000.00 "
     end
-    
+
     it 'displays time, credit, debit, balance all at once' do
       subject = described_class.new(credit: 20000, debit:10000, balance: 200000)
 

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -5,37 +5,32 @@ require 'transaction'
 describe Transaction do
   describe '.display' do
     it 'has the time in the first column' do
-      @test_time_format = Time.now.strftime('%d/%m/%Y')
-
-      expect(subject.display).to eq "#{@test_time_format} || || || "
+      expect(subject.display).to eq "#{test_time_format} || || || "
     end
     
     it 'has the credit it is initialised with in the second column' do
-      @test_time_format = Time.now.strftime('%d/%m/%Y')
       subject = described_class.new(credit: 500)
-
-      expect(subject.display).to eq "#{@test_time_format} || 500.00 || || "
+      expect(subject.display).to eq "#{test_time_format} || 500.00 || || "
     end
     
     it 'has the debit it is initialised with in the second column' do
-      @test_time_format = Time.now.strftime('%d/%m/%Y')
       subject = described_class.new(debit: 500)
-
-      expect(subject.display).to eq "#{@test_time_format} || || 500.00 || "
+      expect(subject.display).to eq "#{test_time_format} || || 500.00 || "
     end
 
     it 'has the balance it is initialised with in the third column' do
-      @test_time_format = Time.now.strftime('%d/%m/%Y')
       subject = described_class.new(balance: 2000)
-
-      expect(subject.display).to eq "#{@test_time_format} || || || 2000.00 "
+      expect(subject.display).to eq "#{test_time_format} || || || 2000.00 "
     end
     
     it 'displays time, credit, debit, balance all at once' do
-      @test_time_format = Time.now.strftime('%d/%m/%Y')
-      subject = described_class.new(credit: 200, debit: 100, balance: 2000)
+      subject = described_class.new(credit: 200, debit:100, balance: 2000)
 
-      expect(subject.display).to eq "#{@test_time_format} || 200.00 || 100.00 || 2000.00 "
+      expect(subject.display).to eq "#{test_time_format} || 200.00 || 100.00 || 2000.00 "
     end
   end
+end
+
+def test_time_format
+  Time.now.strftime('%d/%m/%Y')
 end

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -12,28 +12,28 @@ describe Transaction do
     
     it 'has the credit it is initialised with in the second column' do
       @test_time_format = Time.now.strftime('%d/%m/%Y')
-      subject = Transaction.new(credit: 500)
+      subject = described_class.new(credit: 500)
 
       expect(subject.display).to eq "#{@test_time_format} || 500.00 || || "
     end
     
     it 'has the debit it is initialised with in the second column' do
       @test_time_format = Time.now.strftime('%d/%m/%Y')
-      subject = Transaction.new(debit: 500)
+      subject = described_class.new(debit: 500)
 
       expect(subject.display).to eq "#{@test_time_format} || || 500.00 || "
     end
 
     it 'has the balance it is initialised with in the third column' do
       @test_time_format = Time.now.strftime('%d/%m/%Y')
-      subject = Transaction.new(balance: 2000)
+      subject = described_class.new(balance: 2000)
 
       expect(subject.display).to eq "#{@test_time_format} || || || 2000.00 "
     end
     
     it 'displays time, credit, debit, balance all at once' do
       @test_time_format = Time.now.strftime('%d/%m/%Y')
-      subject = Transaction.new(credit: 200, debit: 100, balance: 2000)
+      subject = described_class.new(credit: 200, debit: 100, balance: 2000)
 
       expect(subject.display).to eq "#{@test_time_format} || 200.00 || 100.00 || 2000.00 "
     end

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -4,31 +4,37 @@ require 'transaction'
 
 describe Transaction do
   describe '.display' do
-    before(:each) do
-      @test_time_format = Time.now.strftime('%d/%m/%Y')
-    end
-
     it 'has the time in the first column' do
+      @test_time_format = Time.now.strftime('%d/%m/%Y')
+
       expect(subject.display).to eq "#{@test_time_format} || || || "
     end
-
+    
     it 'has the credit it is initialised with in the second column' do
+      @test_time_format = Time.now.strftime('%d/%m/%Y')
       subject = Transaction.new(credit: 500)
+
       expect(subject.display).to eq "#{@test_time_format} || 500.00 || || "
     end
-
+    
     it 'has the debit it is initialised with in the second column' do
+      @test_time_format = Time.now.strftime('%d/%m/%Y')
       subject = Transaction.new(debit: 500)
+
       expect(subject.display).to eq "#{@test_time_format} || || 500.00 || "
     end
 
     it 'has the balance it is initialised with in the third column' do
+      @test_time_format = Time.now.strftime('%d/%m/%Y')
       subject = Transaction.new(balance: 2000)
+
       expect(subject.display).to eq "#{@test_time_format} || || || 2000.00 "
     end
-
+    
     it 'displays time, credit, debit, balance all at once' do
+      @test_time_format = Time.now.strftime('%d/%m/%Y')
       subject = Transaction.new(credit: 200, debit: 100, balance: 2000)
+
       expect(subject.display).to eq "#{@test_time_format} || 200.00 || 100.00 || 2000.00 "
     end
   end

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -9,22 +9,22 @@ describe Transaction do
     end
     
     it 'has the credit it is initialised with in the second column' do
-      subject = described_class.new(credit: 500)
+      subject = described_class.new(credit: 50000)
       expect(subject.display).to eq "#{test_time_format} || 500.00 || || "
     end
     
     it 'has the debit it is initialised with in the second column' do
-      subject = described_class.new(debit: 500)
+      subject = described_class.new(debit: 50000)
       expect(subject.display).to eq "#{test_time_format} || || 500.00 || "
     end
 
     it 'has the balance it is initialised with in the third column' do
-      subject = described_class.new(balance: 2000)
+      subject = described_class.new(balance: 200000)
       expect(subject.display).to eq "#{test_time_format} || || || 2000.00 "
     end
     
     it 'displays time, credit, debit, balance all at once' do
-      subject = described_class.new(credit: 200, debit:100, balance: 2000)
+      subject = described_class.new(credit: 20000, debit:10000, balance: 200000)
 
       expect(subject.display).to eq "#{test_time_format} || 200.00 || 100.00 || 2000.00 "
     end


### PR DESCRIPTION
- Reorder README
- Add Table of Contents to README
- Add Rubocop config section to README
- Clarify on method usage in instructions
- Switched to message instead of runtime error for withdrawing too much
- renamed variable with digits in their names
- Use regex to avoid long string in statement tests
- Refactor let, before and subject blocks to setup methods
- Start using present tense commit names
- Implement printer class, refactor Account to use this to print
- Rename history to transaction_history
- Implement pence conversion from float and presentation as pounds/pence using Covnersion module.